### PR TITLE
Add show argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,13 @@ program
   });
 
 program
+  .command('show <timestamp>')
+  .description('show todo')
+  .action(function(timestamp, options){
+    todo.show(timestamp);
+  });
+
+program
   .command('edit <timestamp> <desc>')
   .description('edit todo')
   .option("-t, --tags <tags>", "update tags on specified todo", utils.list)

--- a/lib/todo.js
+++ b/lib/todo.js
@@ -168,6 +168,23 @@ function Todo() {
       syncDB();
     });
   }
+
+  this.show = function(timestamp) {
+    localDB.get(timestamp, function(err, doc) {
+      var data = [];
+
+      if (err) { return console.log(err); }
+      console.log(chalk.black.bgCyan('Show'));
+      data.push(
+        [ headerColour('ID'), doc._id ],
+        [ headerColour('Status'), doc.status ],
+        [ headerColour('Description'), doc.description ],
+        [ headerColour('Tags'), doc.tags.join(',') ]
+      );
+      console.log(utils.vertTable(data));
+      syncDB();
+    });
+  }
 }
 
 function syncDB() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chexbox",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A cli-based todo app w/ offline synching",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The items returned by list are truncated, meaning it may not be possible
to obtain full details of the todo in question.  This commit adds a new
show argument which will return the todo description in its entirety.